### PR TITLE
Fix architecture check for OS X

### DIFF
--- a/src/main/java/org/zwave4j/NativeLibraryLoader.java
+++ b/src/main/java/org/zwave4j/NativeLibraryLoader.java
@@ -115,6 +115,6 @@ public class NativeLibraryLoader {
     }
 
     private static boolean isAmd64(String architecture) {
-        return architecture.endsWith("64");
+        return architecture.equals("amd64") || architecture.equals("x86_64");
     }
 }

--- a/src/main/java/org/zwave4j/NativeLibraryLoader.java
+++ b/src/main/java/org/zwave4j/NativeLibraryLoader.java
@@ -115,6 +115,6 @@ public class NativeLibraryLoader {
     }
 
     private static boolean isAmd64(String architecture) {
-        return architecture.equals("amd64");
+        return architecture.endsWith("64");
     }
 }


### PR DESCRIPTION
x86_64 is also a valid architecture, as used by OS X.
