### PR TITLE
Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+*.iml
+gradle.properties

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
+.gradle
 *.iml
 gradle.properties
+build


### PR DESCRIPTION
Also ignores the `gradle.properties` as you have the `example.gradle.properties`, so I figured you did not want to check in gradle.properties as it is specific to each developer.
