### PR TITLE
fix link error on El Capitan

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -340,7 +340,7 @@ model {
                         }
                     } else if (targetPlatform.operatingSystem.macOsX) {
                         if (toolChain in Gcc || toolChain in Clang) {
-                            linker.args "-framework", "IOKit", "-framework", "CoreFoundation"
+                            linker.args ""
                         }
                     }
 
@@ -369,7 +369,7 @@ model {
                     cppCompiler.define "DARWIN"
                     cppCompiler.args "-mmacosx-version-min=10.4"
                     cCompiler.args "-mmacosx-version-min=10.4"
-                    linker.args "-mmacosx-version-min=10.4"
+                    linker.args "-mmacosx-version-min=10.4", "-framework", "IOKit", "-framework", "CoreFoundation"
                 }
             }
         }


### PR DESCRIPTION
fixes the following link error:

```
:compileHidApiOsx_x86-64SharedLibraryHidApiOsx_x86-64SharedLibraryC
:linkHidApiOsx_x86-64SharedLibrary
Undefined symbols for architecture x86_64:
  "_CFGetTypeID", referenced from:
      _get_int_property in hid.o
  "_CFNumberGetTypeID", referenced from:
      _get_int_property in hid.o
  "_CFNumberGetValue", referenced from:
      _get_int_property in hid.o
  "_CFRelease", referenced from:
      _hid_exit in hid.o
      _hid_enumerate in hid.o
      _hid_open_path in hid.o
      _free_hid_device in hid.o
      _hid_close in hid.o
  "_CFRetain", referenced from:
      _hid_open_path in hid.o
  "_CFRunLoopAddSource", referenced from:
      _read_thread in hid.o
  "_CFRunLoopGetCurrent", referenced from:
      _init_hid_manager in hid.o
      _read_thread in hid.o
  "_CFRunLoopGetMain", referenced from:
      _hid_close in hid.o
  "_CFRunLoopRunInMode", referenced from:
      _process_pending_events in hid.o
      _read_thread in hid.o
  "_CFRunLoopSourceCreate", referenced from:
      _read_thread in hid.o
  "_CFRunLoopSourceSignal", referenced from:
      _hid_close in hid.o
  "_CFRunLoopStop", referenced from:
      _hid_device_removal_callback in hid.o
      _perform_signal_callback in hid.o
  "_CFRunLoopWakeUp", referenced from:
      _hid_close in hid.o
  "_CFSetGetCount", referenced from:
      _hid_enumerate in hid.o
      _hid_open_path in hid.o
  "_CFSetGetValues", referenced from:
      _hid_enumerate in hid.o
      _hid_open_path in hid.o
  "_CFStringCreateWithCString", referenced from:
      _hid_open_path in hid.o
  "_CFStringGetBytes", referenced from:
      _get_string_property_utf8 in hid.o
      _get_string_property in hid.o
  "_CFStringGetLength", referenced from:
      _get_string_property_utf8 in hid.o
      _get_string_property in hid.o
  "_IOHIDDeviceClose", referenced from:
      _hid_close in hid.o
  "_IOHIDDeviceGetProperty", referenced from:
      _get_int_property in hid.o
      _get_string_property_utf8 in hid.o
      _get_string_property in hid.o
  "_IOHIDDeviceGetReport", referenced from:
      _hid_get_feature_report in hid.o
  "_IOHIDDeviceOpen", referenced from:
      _hid_open_path in hid.o
  "_IOHIDDeviceRegisterInputReportCallback", referenced from:
      _hid_open_path in hid.o
      _hid_close in hid.o
  "_IOHIDDeviceRegisterRemovalCallback", referenced from:
      _hid_open_path in hid.o
  "_IOHIDDeviceScheduleWithRunLoop", referenced from:
      _read_thread in hid.o
      _hid_close in hid.o
  "_IOHIDDeviceSetReport", referenced from:
      _set_report in hid.o
  "_IOHIDDeviceUnscheduleFromRunLoop", referenced from:
      _hid_close in hid.o
  "_IOHIDManagerClose", referenced from:
      _hid_exit in hid.o
  "_IOHIDManagerCopyDevices", referenced from:
      _hid_enumerate in hid.o
      _hid_open_path in hid.o
  "_IOHIDManagerCreate", referenced from:
      _init_hid_manager in hid.o
  "_IOHIDManagerRegisterDeviceRemovalCallback", referenced from:
      _hid_close in hid.o
  "_IOHIDManagerScheduleWithRunLoop", referenced from:
      _init_hid_manager in hid.o
  "_IOHIDManagerSetDeviceMatching", referenced from:
      _init_hid_manager in hid.o
  "___CFConstantStringClassReference", referenced from:
      CFString in hid.o
      CFString in hid.o
      CFString in hid.o
      CFString in hid.o
      CFString in hid.o
      CFString in hid.o
      CFString in hid.o
      ...
  "_kCFAllocatorDefault", referenced from:
      _init_hid_manager in hid.o
      _read_thread in hid.o
  "_kCFRunLoopDefaultMode", referenced from:
      _init_hid_manager in hid.o
      _process_pending_events in hid.o
      _hid_close in hid.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)

:linkHidApiOsx_x86-64SharedLibrary FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':linkHidApiOsx_x86-64SharedLibrary'.
> A build operation failed.
      Linker failed while linking libhidApi.dylib.
```
